### PR TITLE
Improve match results: per-category detail + scripts

### DIFF
--- a/apps/orchestration/package.json
+++ b/apps/orchestration/package.json
@@ -12,6 +12,8 @@
   },
   "scripts": {
     "dev": "node --env-file=../../.env src/index.js",
+    "requeue": "node --env-file=../../.env scripts/requeue-all.js",
+    "check-detail": "node --env-file=../../.env scripts/check-detail.js",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/orchestration/scripts/check-detail.js
+++ b/apps/orchestration/scripts/check-detail.js
@@ -1,0 +1,130 @@
+// @ts-check
+//
+// Inspects match-run-results documents for rollout health of the per-category
+// detail blobs (locationDetail / emrDetail / durationDetail). Reports counts,
+// flag distribution, and method distribution per category. Optionally prints a
+// sample document matching a given flag or method.
+//
+// Usage:
+//   node --env-file=../../.env scripts/check-detail.js
+//   node --env-file=../../.env scripts/check-detail.js --sample-flag emr_mismatch
+//   node --env-file=../../.env scripts/check-detail.js --sample-method location=gps_distance
+
+import { connect, disconnect, getDb, COLLECTIONS } from '@locvm/database'
+
+const DETAIL_CATEGORIES = /** @type {const} */ (['location', 'emr', 'duration'])
+
+const args = process.argv.slice(2)
+const sampleFlag = readArg(args, '--sample-flag')
+const sampleMethod = readArg(args, '--sample-method') // form: "<category>=<method>"
+
+await connect()
+try {
+  await run()
+} finally {
+  await disconnect()
+}
+
+async function run() {
+  const db = await getDb()
+  const results = db.collection(COLLECTIONS.MATCH_RUN_RESULTS)
+
+  const baseQuery = { isActive: true }
+  const withDetailQuery = { ...baseQuery, 'breakdown.locationDetail': { $exists: true } }
+
+  const [total, withDetail] = await Promise.all([
+    results.countDocuments(baseQuery),
+    results.countDocuments(withDetailQuery),
+  ])
+
+  console.log(`Active results: ${total} total, ${withDetail} with detail`)
+  if (total > 0) {
+    const pct = ((withDetail / total) * 100).toFixed(1)
+    console.log(`Detail coverage: ${pct}%`)
+  }
+
+  // Aggregate flag + method distributions in a single pass over the rolled-out subset.
+  /** @type {Record<string, number>} */
+  const flagCounts = {}
+  /** @type {Record<string, Record<string, number>>} */
+  const methodCounts = Object.fromEntries(DETAIL_CATEGORIES.map((c) => [c, {}]))
+
+  const cursor = results.find(withDetailQuery)
+  for await (const doc of cursor) {
+    for (const f of doc.flags ?? []) {
+      flagCounts[f] = (flagCounts[f] ?? 0) + 1
+    }
+    for (const category of DETAIL_CATEGORIES) {
+      const method = doc.breakdown?.[`${category}Detail`]?.method
+      if (typeof method === 'string') {
+        methodCounts[category][method] = (methodCounts[category][method] ?? 0) + 1
+      }
+    }
+  }
+
+  console.log('\nFlag counts:')
+  printSorted(flagCounts)
+
+  for (const category of DETAIL_CATEGORIES) {
+    console.log(`\n${category} method counts:`)
+    printSorted(methodCounts[category])
+  }
+
+  if (sampleFlag) await printSample(results, { ...withDetailQuery, flags: sampleFlag }, `flag=${sampleFlag}`)
+  if (sampleMethod) {
+    const [category, method] = sampleMethod.split('=')
+    if (!category || !method || !DETAIL_CATEGORIES.includes(/** @type {any} */ (category))) {
+      console.error(`\nInvalid --sample-method "${sampleMethod}". Expected "<category>=<method>".`)
+      return
+    }
+    await printSample(
+      results,
+      { ...withDetailQuery, [`breakdown.${category}Detail.method`]: method },
+      `${category}.method=${method}`
+    )
+  }
+}
+
+/**
+ * @param {import('mongodb').Collection} collection
+ * @param {Record<string, unknown>} query
+ * @param {string} label
+ */
+async function printSample(collection, query, label) {
+  const sample = await collection.findOne(query)
+  if (!sample) {
+    console.log(`\nNo sample found for ${label}`)
+    return
+  }
+  console.log(`\nSample (${label}):`)
+  console.log(JSON.stringify({ flags: sample.flags, breakdown: sample.breakdown }, null, 2))
+}
+
+/**
+ * Pretty-print a count map sorted by descending count.
+ *
+ * @param {Record<string, number>} counts
+ */
+function printSorted(counts) {
+  const entries = Object.entries(counts).sort((a, b) => b[1] - a[1])
+  if (entries.length === 0) {
+    console.log('  (none)')
+    return
+  }
+  for (const [key, count] of entries) {
+    console.log(`  ${key}: ${count}`)
+  }
+}
+
+/**
+ * @param {string[]} argv
+ * @param {string} name
+ * @returns {string | null}
+ */
+function readArg(argv, name) {
+  const i = argv.indexOf(name)
+  if (i === -1) return null
+  const value = argv[i + 1]
+  if (!value || value.startsWith('--')) return null
+  return value
+}

--- a/apps/orchestration/scripts/requeue-all.js
+++ b/apps/orchestration/scripts/requeue-all.js
@@ -1,0 +1,125 @@
+// @ts-check
+//
+// Bulk requeue: re-triggers matching for every physician, every job, or both,
+// by firing the same HTTP endpoints the orchestration service exposes to
+// upstream producers. Useful after scorer changes or to stress-test the drain queue.
+//
+// Usage:
+//   node --env-file=../../.env scripts/requeue-all.js --physicians
+//   node --env-file=../../.env scripts/requeue-all.js --jobs
+//   node --env-file=../../.env scripts/requeue-all.js --all
+
+import { connect, disconnect, getDb, COLLECTIONS } from '@locvm/database'
+
+const SERVICE_URL = process.env.MATCHING_SERVICE_URL ?? 'http://localhost:3001'
+const SERVICE_SECRET = process.env.MATCHING_SERVICE_SECRET ?? ''
+
+/**
+ * @typedef {Object} RequeueTarget
+ * @property {string} label - human label used in console output
+ * @property {string} endpoint - orchestration HTTP path to POST to
+ * @property {string} collection - Mongo collection to enumerate
+ * @property {Record<string, unknown>} query - filter applied when enumerating
+ * @property {'jobId' | 'physicianId'} bodyKey - JSON key the endpoint expects
+ */
+
+/** @type {RequeueTarget} */
+const PHYSICIANS = {
+  label: 'physicians',
+  endpoint: '/physician-updated',
+  collection: COLLECTIONS.USERS,
+  query: { medProfession: 'Physician', isOnboardingCompleted: true },
+  bodyKey: 'physicianId',
+}
+
+/** @type {RequeueTarget} */
+const JOBS = {
+  label: 'jobs',
+  endpoint: '/job-posted',
+  collection: COLLECTIONS.LOCUM_JOBS,
+  query: {},
+  bodyKey: 'jobId',
+}
+
+const args = new Set(process.argv.slice(2))
+const wantAll = args.has('--all')
+const targets = [
+  ...(wantAll || args.has('--physicians') ? [PHYSICIANS] : []),
+  ...(wantAll || args.has('--jobs') ? [JOBS] : []),
+]
+
+if (targets.length === 0) {
+  console.error('Usage: requeue-all.js --physicians | --jobs | --all')
+  process.exit(1)
+}
+
+/**
+ * Fires a single requeue request. Errors are returned, not thrown, so one
+ * failure doesn't abort the rest of the batch.
+ *
+ * @param {RequeueTarget} target
+ * @param {string} id
+ * @returns {Promise<{ id: string, ok: boolean, error?: string }>}
+ */
+async function trigger(target, id) {
+  try {
+    const res = await fetch(`${SERVICE_URL}${target.endpoint}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(SERVICE_SECRET ? { Authorization: `Bearer ${SERVICE_SECRET}` } : {}),
+      },
+      body: JSON.stringify({ [target.bodyKey]: id }),
+    })
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    return { id, ok: true }
+  } catch (err) {
+    return { id, ok: false, error: /** @type {Error} */ (err).message }
+  }
+}
+
+/**
+ * @param {string} label
+ * @param {Array<{ id: string, ok: boolean, error?: string }>} results
+ * @param {number} elapsedMs
+ */
+function report(label, results, elapsedMs) {
+  const ok = results.filter((r) => r.ok).length
+  const failed = results.filter((r) => !r.ok)
+  console.log(`[${label}] ${ok} queued, ${failed.length} failed — ${(elapsedMs / 1000).toFixed(2)}s`)
+  for (const r of failed) console.log(`  ${r.id} — ${r.error}`)
+}
+
+/**
+ * Enumerate `target.collection` and fan out concurrent requeue requests.
+ *
+ * @param {RequeueTarget} target
+ */
+async function requeueTarget(target) {
+  const db = await getDb()
+  const docs = await db
+    .collection(target.collection)
+    .find(target.query, { projection: { _id: 1 } })
+    .toArray()
+
+  console.log(`Triggering ${docs.length} ${target.label}...`)
+  const start = Date.now()
+  const results = await Promise.all(docs.map((d) => trigger(target, d._id.toString())))
+  report(target.label, results, Date.now() - start)
+}
+
+async function run() {
+  await connect()
+  try {
+    for (const target of targets) {
+      await requeueTarget(target)
+    }
+  } finally {
+    await disconnect()
+  }
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/matching-engine/src/scoring/__tests__/combineAndRank.test.js
+++ b/packages/matching-engine/src/scoring/__tests__/combineAndRank.test.js
@@ -139,6 +139,37 @@ describe('breakdown keys', () => {
     const { breakdown } = computeWeightedScore({ location: 0.8, emr: 0.3 })
     expect(Object.keys(breakdown).sort()).toEqual(['emr', 'location'])
   })
+
+  it('passes through *Detail blobs unchanged', () => {
+    /** @type {import('@locvm/types').LocationDetail} */
+    const locationDetail = {
+      method: 'gps_distance',
+      distanceKm: 12.5,
+      distanceBucket: 'nearby',
+      matchedRegion: null,
+      physicianProvince: 'ON',
+      jobProvince: 'ON',
+      provinceMatch: true,
+    }
+    /** @type {import('@locvm/types').EMRDetail} */
+    const emrDetail = {
+      method: 'match',
+      jobEMR: 'ps suite',
+      physicianEMRs: ['ps suite'],
+      matched: true,
+    }
+
+    const { breakdown } = computeWeightedScore({
+      location: 0.9,
+      emr: 1,
+      locationDetail,
+      emrDetail,
+    })
+
+    expect(breakdown.locationDetail).toEqual(locationDetail)
+    expect(breakdown.emrDetail).toEqual(emrDetail)
+    expect(breakdown.durationDetail).toBeUndefined()
+  })
 })
 
 // ─── combineAndRank ────────────────────────────────────────────────────────

--- a/packages/matching-engine/src/scoring/__tests__/score-match.test.js
+++ b/packages/matching-engine/src/scoring/__tests__/score-match.test.js
@@ -1,0 +1,195 @@
+// @ts-check
+
+import { describe, it, expect } from 'vitest'
+import { scoreMatch } from '../score-match.js'
+import { makePhysician, dateRange } from '../../../tests/helpers/factories.js'
+
+/** @typedef {import('@locvm/types').LocumJob} LocumJob */
+
+/** @param {Partial<LocumJob>} [overrides] */
+function makeJob(overrides = {}) {
+  return /** @type {LocumJob} */ ({
+    _id: 'test-job',
+    medProfession: 'Physician',
+    medSpeciality: 'Family Medicine',
+    location: null,
+    fullAddress: { city: 'Toronto', province: 'ON' },
+    dateRange: dateRange('2025-01-01', '2025-03-01'),
+    ...overrides,
+  })
+}
+
+// ─── Identity passthrough ──────────────────────────────────────────────────
+
+describe('scoreMatch – identity', () => {
+  it('echoes physicianId and jobId', () => {
+    const physician = makePhysician({ _id: 'phys-7' })
+    const job = makeJob({ _id: 'job-42' })
+
+    const result = scoreMatch(physician, job)
+
+    expect(result.physicianId).toBe('phys-7')
+    expect(result.jobId).toBe('job-42')
+  })
+})
+
+// ─── Breakdown shape ───────────────────────────────────────────────────────
+
+describe('scoreMatch – breakdown shape', () => {
+  it('produces a score and a detail blob for every category', () => {
+    const { breakdown } = scoreMatch(makePhysician(), makeJob())
+
+    expect(typeof breakdown.location).toBe('number')
+    expect(typeof breakdown.emr).toBe('number')
+    expect(typeof breakdown.duration).toBe('number')
+
+    expect(breakdown.locationDetail).toMatchObject({
+      method: expect.any(String),
+      distanceBucket: expect.any(String),
+      provinceMatch: expect.any(Boolean),
+    })
+    expect(breakdown.emrDetail).toMatchObject({
+      method: expect.any(String),
+      physicianEMRs: expect.any(Array),
+      matched: expect.any(Boolean),
+    })
+    expect(breakdown.durationDetail).toMatchObject({
+      method: expect.any(String),
+      usedBucketFallback: expect.any(Boolean),
+    })
+  })
+
+  it('omits durationDetail when the job has no dateRange', () => {
+    const job = makeJob({ dateRange: /** @type {any} */ (undefined) })
+    const { breakdown, flags } = scoreMatch(makePhysician(), job)
+
+    expect(breakdown.duration).toBeUndefined()
+    expect(breakdown.durationDetail).toBeUndefined()
+    expect(flags).toContain('no_job_date_range')
+  })
+})
+
+// ─── Location flags ────────────────────────────────────────────────────────
+
+describe('scoreMatch – location flags', () => {
+  it('flags "no_location_data" when neither side has any location signal', () => {
+    const physician = makePhysician({
+      location: null,
+      workAddress: null,
+      preferredProvinces: [],
+      specificRegions: [],
+      medicalProvince: undefined,
+    })
+    const job = makeJob({ location: null, fullAddress: /** @type {any} */ ({}) })
+
+    const { flags, breakdown } = scoreMatch(physician, job)
+
+    expect(flags).toContain('no_location_data')
+    expect(breakdown.locationDetail?.method).toBe('no_data')
+  })
+
+  it('flags "location_province_only" when the score is province-derived (no GPS)', () => {
+    const physician = makePhysician({
+      location: null,
+      preferredProvinces: ['ON'],
+    })
+    const job = makeJob({ location: null })
+
+    const { flags, breakdown } = scoreMatch(physician, job)
+
+    expect(flags).toContain('location_province_only')
+    expect(breakdown.locationDetail?.method).toBe('preferred_province')
+  })
+
+  it('does NOT flag "location_province_only" when GPS distance was used', () => {
+    const physician = makePhysician({ location: { lat: 43.65, lng: -79.38 } })
+    const job = makeJob({ location: { lat: 43.7, lng: -79.4 } })
+
+    const { flags, breakdown } = scoreMatch(physician, job)
+
+    expect(flags).not.toContain('location_province_only')
+    expect(breakdown.locationDetail?.method).toBe('gps_distance')
+  })
+})
+
+// ─── EMR flags ─────────────────────────────────────────────────────────────
+
+describe('scoreMatch – EMR flags', () => {
+  it('flags "no_physician_emr" when physician has no EMR data', () => {
+    const job = makeJob({ facilityInfo: { emr: 'PS Suite' } })
+
+    const { flags, breakdown } = scoreMatch(makePhysician({ emrSystems: [] }), job)
+
+    expect(flags).toContain('no_physician_emr')
+    expect(breakdown.emrDetail?.method).toBe('no_physician_emr')
+  })
+
+  it('flags "no_job_emr" when the job has no EMR field', () => {
+    const physician = makePhysician({ emrSystems: ['PS Suite'] })
+    const job = makeJob({ facilityInfo: undefined })
+
+    const { flags, breakdown } = scoreMatch(physician, job)
+
+    expect(flags).toContain('no_job_emr')
+    expect(breakdown.emrDetail?.method).toBe('no_job_emr')
+  })
+
+  it('flags "emr_mismatch" when both sides have EMRs but none match', () => {
+    const physician = makePhysician({ emrSystems: ['Accuro'] })
+    const job = makeJob({ facilityInfo: { emr: 'PS Suite' } })
+
+    const { flags, breakdown } = scoreMatch(physician, job)
+
+    expect(flags).toContain('emr_mismatch')
+    expect(breakdown.emrDetail?.method).toBe('no_match')
+  })
+
+  it('emits no EMR flag on a successful match', () => {
+    const physician = makePhysician({ emrSystems: ['PS Suite'] })
+    const job = makeJob({ facilityInfo: { emr: 'PS Suite' } })
+
+    const { flags } = scoreMatch(physician, job)
+
+    expect(flags).not.toContain('emr_mismatch')
+    expect(flags).not.toContain('no_physician_emr')
+    expect(flags).not.toContain('no_job_emr')
+  })
+})
+
+// ─── Duration flags ────────────────────────────────────────────────────────
+
+describe('scoreMatch – duration flags', () => {
+  it('flags "no_duration_data" when physician has no availability or bucket data', () => {
+    const physician = makePhysician({ availabilityWindows: [], locumDurations: [] })
+    const job = makeJob({ dateRange: dateRange('2025-01-01', '2025-01-31') })
+
+    const { flags, breakdown } = scoreMatch(physician, job)
+
+    expect(flags).toContain('no_duration_data')
+    expect(breakdown.durationDetail?.method).toBe('neutral')
+  })
+
+  it('flags "low_date_overlap" when overlap with availability is below 50%', () => {
+    const physician = makePhysician({
+      availabilityWindows: [{ from: new Date('2025-01-01'), to: new Date('2025-01-10') }],
+    })
+    const job = makeJob({ dateRange: dateRange('2025-01-01', '2025-01-31') })
+
+    const { flags, breakdown } = scoreMatch(physician, job)
+
+    expect(flags).toContain('low_date_overlap')
+    expect(breakdown.durationDetail?.method).toBe('overlap')
+    expect(breakdown.durationDetail?.overlapPct).toBeLessThan(0.5)
+  })
+
+  it('does NOT flag "low_date_overlap" when overlap exceeds 50%', () => {
+    const physician = makePhysician({
+      availabilityWindows: [{ from: new Date('2025-01-01'), to: new Date('2025-01-31') }],
+    })
+    const job = makeJob({ dateRange: dateRange('2025-01-01', '2025-01-31') })
+
+    const { flags } = scoreMatch(physician, job)
+
+    expect(flags).not.toContain('low_date_overlap')
+  })
+})

--- a/packages/matching-engine/src/scoring/combineAndRank.js
+++ b/packages/matching-engine/src/scoring/combineAndRank.js
@@ -27,7 +27,8 @@ function round2(n) {
 /**
  * Compute the weighted score for a single pair with re-normalization for missing categories.
  *
- * Returns totalScore in [0, 5] and breakdown with each category's raw 0-1 score.
+ * Returns totalScore in [0, 5] and a breakdown carrying each category's raw 0-1
+ * score plus any `<category>Detail` blob the scorer produced.
  *
  * @param {ScoreBreakdown} breakdown - per-category 0-1 scores (undefined = not scored)
  * @returns {{ totalScore: number, breakdown: ScoreBreakdown }}
@@ -42,9 +43,8 @@ export function computeWeightedScore(breakdown) {
     const score = breakdown[category]
     if (score === undefined || score === null) continue
 
-    const weight = WEIGHTS[category]
-    weightSum += weight
-    weightedSum += score * weight
+    weightSum += WEIGHTS[category]
+    weightedSum += score * WEIGHTS[category]
     outBreakdown[category] = round2(score)
   }
 
@@ -52,12 +52,28 @@ export function computeWeightedScore(breakdown) {
     return { totalScore: 0, breakdown: {} }
   }
 
-  // Re-normalize: divide by the sum of available weights (not 1.0)
-  // This redistributes missing categories' weights proportionally
-  // Scale to 0-5 range
+  copyScorerDetails(breakdown, outBreakdown)
+
+  // Re-normalize by the *available* weight sum (not 1.0) so missing categories
+  // don't drag the score down — their weight is redistributed proportionally.
+  // Final score is scaled to the 0-5 product range.
   const totalScore = Math.min(5, Math.max(0, round2((weightedSum / weightSum) * 5)))
 
   return { totalScore, breakdown: outBreakdown }
+}
+
+/**
+ * Carry over the `*Detail` blobs from input to output untouched. These are
+ * informational only (no math) — they're preserved so the UI and analytics
+ * can explain *why* each category scored what it did.
+ *
+ * @param {ScoreBreakdown} from
+ * @param {ScoreBreakdown} to
+ */
+function copyScorerDetails(from, to) {
+  if (from.locationDetail) to.locationDetail = from.locationDetail
+  if (from.durationDetail) to.durationDetail = from.durationDetail
+  if (from.emrDetail) to.emrDetail = from.emrDetail
 }
 
 /**

--- a/packages/matching-engine/src/scoring/score-match.js
+++ b/packages/matching-engine/src/scoring/score-match.js
@@ -1,43 +1,136 @@
 // @ts-check
 
-import { scoreLocation } from './location/scoreLocation.js'
-import { scoreEMR } from './emr/scoreEMR.js'
+import { scoreLocationWithDetail } from './location/scoreLocation.js'
+import { scoreEMRWithDetail } from './emr/scoreEMR.js'
 import { createDurationScorer } from './duration/scoreDuration.js'
 
 /** @typedef {import('@locvm/types').Physician} Physician */
 /** @typedef {import('@locvm/types').LocumJob} LocumJob */
 /** @typedef {import('@locvm/types').ScoredPair} ScoredPair */
+/** @typedef {import('@locvm/types').ScoreBreakdown} ScoreBreakdown */
 
 const scoreDuration = createDurationScorer()
 
+// Location scoring tiers that did not use GPS — useful for the UI to caveat
+// "matched by province only" results.
+const PROVINCE_ONLY_LOCATION_METHODS = new Set(['preferred_province', 'work_province', 'medical_province'])
+
+// Below this overlap ratio between the physician's availability and the job's
+// date range, we surface a "low_date_overlap" flag so reviewers can spot
+// borderline matches at a glance.
+const LOW_DATE_OVERLAP_THRESHOLD = 0.5
+
 /**
- * Scores one physician-job pair across all categories. Returns raw 0-1 scores per category.
+ * Scores one physician-job pair across all categories.
+ *
+ * For each category we store both the raw 0-1 score AND a `<category>Detail`
+ * object describing the signals that produced it (distance, EMR names, overlap %).
+ * The detail blobs let the UI and analytics explain *why* a match scored what
+ * it did without re-running the scorers.
  *
  * @param {Physician} physician
  * @param {LocumJob} job
  * @returns {ScoredPair}
  */
 export function scoreMatch(physician, job) {
-  /** @type {import('@locvm/types').ScoreBreakdown} */
+  /** @type {ScoreBreakdown} */
   const breakdown = {}
   /** @type {string[]} */
   const flags = []
 
-  breakdown.location = scoreLocation(physician, job.location, job.fullAddress)
-  if (!physician.workAddress && !physician.location) flags.push('missing_physician_location')
-
-  breakdown.emr = scoreEMR(physician, job)
-
-  if (job.dateRange) {
-    breakdown.duration = scoreDuration(physician, job.dateRange).score
-  } else {
-    flags.push('missing_job_date_range')
-  }
+  applyLocationCategory(physician, job, breakdown, flags)
+  applyEMRCategory(physician, job, breakdown, flags)
+  applyDurationCategory(physician, job, breakdown, flags)
 
   return {
     physicianId: physician._id,
     jobId: job._id,
     breakdown,
     flags,
+  }
+}
+
+/**
+ * @param {Physician} physician
+ * @param {LocumJob} job
+ * @param {ScoreBreakdown} breakdown
+ * @param {string[]} flags
+ */
+function applyLocationCategory(physician, job, breakdown, flags) {
+  const result = scoreLocationWithDetail(physician, job.location, job.fullAddress)
+
+  breakdown.location = result.score
+  breakdown.locationDetail = {
+    method: result.method,
+    distanceKm: result.distanceKm,
+    distanceBucket: result.distanceBucket,
+    matchedRegion: result.matchedRegion,
+    physicianProvince: result.resolvedPhysicianProvince,
+    jobProvince: result.resolvedJobProvince,
+    provinceMatch: result.provinceMatch,
+  }
+
+  if (result.method === 'no_data') {
+    flags.push('no_location_data')
+  } else if (PROVINCE_ONLY_LOCATION_METHODS.has(result.method)) {
+    flags.push('location_province_only')
+  }
+}
+
+/**
+ * @param {Physician} physician
+ * @param {LocumJob} job
+ * @param {ScoreBreakdown} breakdown
+ * @param {string[]} flags
+ */
+function applyEMRCategory(physician, job, breakdown, flags) {
+  const result = scoreEMRWithDetail(physician, job)
+
+  breakdown.emr = result.score
+  breakdown.emrDetail = {
+    method: result.method,
+    jobEMR: result.jobEMR,
+    physicianEMRs: result.physicianEMRs,
+    matched: result.matched,
+  }
+
+  switch (result.method) {
+    case 'no_physician_emr':
+      flags.push('no_physician_emr')
+      break
+    case 'no_job_emr':
+      flags.push('no_job_emr')
+      break
+    case 'no_match':
+      flags.push('emr_mismatch')
+      break
+  }
+}
+
+/**
+ * @param {Physician} physician
+ * @param {LocumJob} job
+ * @param {ScoreBreakdown} breakdown
+ * @param {string[]} flags
+ */
+function applyDurationCategory(physician, job, breakdown, flags) {
+  if (!job.dateRange) {
+    flags.push('no_job_date_range')
+    return
+  }
+
+  const result = scoreDuration(physician, job.dateRange)
+
+  breakdown.duration = result.score
+  breakdown.durationDetail = {
+    method: result.breakdown.method,
+    overlapPct: result.breakdown.overlapPct,
+    usedBucketFallback: result.breakdown.usedBucketFallback,
+  }
+
+  if (result.breakdown.method === 'neutral') {
+    flags.push('no_duration_data')
+  } else if (result.breakdown.overlapPct !== null && result.breakdown.overlapPct < LOW_DATE_OVERLAP_THRESHOLD) {
+    flags.push('low_date_overlap')
   }
 }

--- a/packages/types/src/matching/matching.js
+++ b/packages/types/src/matching/matching.js
@@ -8,13 +8,39 @@
 // SearchResult = what comes back
 
 /**
- * Per-category score breakdown. Each field is the score for that category.
- * undefined = that category wasnt scored (different from 0)
+ * Per-category 0-1 score plus an optional `*Detail` object explaining how that
+ * score was produced. `undefined` means the category was not scored (different from 0).
+ *
+ * The `*Detail` shapes are intentionally loose at this layer the scorers own the
+ * concrete fields, and consumers (UI, analytics) read them as plain JSON.
+ *
+ * @typedef {Object} LocationDetail
+ * @property {'gps_distance'|'specific_region'|'preferred_province'|'work_province'|'medical_province'|'no_data'} method
+ * @property {number | null} distanceKm
+ * @property {'same_city'|'nearby'|'regional'|'far'|'very_far'|'unknown'} distanceBucket
+ * @property {string | null} matchedRegion
+ * @property {string | null} physicianProvince
+ * @property {string | null} jobProvince
+ * @property {boolean} provinceMatch
+ *
+ * @typedef {Object} EMRDetail
+ * @property {'match'|'no_match'|'no_job_emr'|'no_physician_emr'} method
+ * @property {string | null} jobEMR
+ * @property {string[]} physicianEMRs
+ * @property {boolean} matched
+ *
+ * @typedef {Object} DurationDetail
+ * @property {'overlap'|'bucket'|'neutral'} method
+ * @property {number | null} overlapPct
+ * @property {boolean} usedBucketFallback
  *
  * @typedef {Object} ScoreBreakdown
  * @property {number} [location]
  * @property {number} [duration]
  * @property {number} [emr]
+ * @property {LocationDetail} [locationDetail]
+ * @property {DurationDetail} [durationDetail]
+ * @property {EMRDetail} [emrDetail]
  */
 
 /**
@@ -27,7 +53,7 @@
  * @property {string} jobId - The job that was matched against
  * @property {number} score - Total match score, 0-5 range. Higher = better
  * @property {ScoreBreakdown} breakdown - Score breakdown by category
- * @property {string[]} [flags] - Data quality flags, e.g. "missing_physician_location", "missing_emr_data"
+ * @property {string[]} [flags] - Data quality / signal flags, e.g. "no_location_data", "emr_mismatch", "low_date_overlap"
  */
 
 /**
@@ -53,7 +79,7 @@
  * @property {string} physicianId
  * @property {string} jobId
  * @property {ScoreBreakdown} breakdown - individual 0-1 scores (location, duration, emr)
- * @property {string[]} flags - Data quality flags, e.g. "missing_physician_location", "missing_emr_data"
+ * @property {string[]} flags - Data quality / signal flags, e.g. "no_location_data", "emr_mismatch", "low_date_overlap"
  */
 
 /**


### PR DESCRIPTION
## Summary

Match results now explain *why* a physician–job pair scored what it did. Every result carries a per-category detail blob (location, EMR, duration) alongside the raw score, plus more precise data-quality flags. Two operator scripts ship alongside: one to bulk re-trigger matching, one to inspect rollout health of the new detail data.

```
{
  "_id": {
    "$oid": "69df31aa73afa816d24dca66"
  },
  "runId": "d33988ad-9858-49c0-ac84-b419d37cbb39",
  "physicianId": "675486959589648f309c1c76",
  "jobId": "69a852b8b6a2cfc16f6a08de",
  "rank": 1,
  "score": 1.63,
  "breakdown": {
    "emr": 0.5,
    "emrDetail": {
      "method": "no_physician_emr",
      "jobEMR": "medesync",
      "physicianEMRs": [],
      "matched": false
    },
    "location": 0,
    "locationDetail": {
      "method": "gps_distance",
      "distanceKm": 306.22,
      "distanceBucket": "very_far",
      "matchedRegion": "Orillia",
      "physicianProvince": "ON",
      "jobProvince": "ON",
      "provinceMatch": true
    },
    "duration": 0.5,
    "durationDetail": {
      "method": "neutral",
      "overlapPct": null,
      "usedBucketFallback": false
    }
  },
  "flags": [],
  "isActive": false,
  "computedAt": {
    "$date": "2026-04-15T06:35:22.671Z"
  },
  "deprecatedAt": {
    "$date": "2026-04-15T08:01:28.007Z"
  }
}
```

## What was done

- [x] Added per-category detail blobs (`locationDetail`, `emrDetail`, `durationDetail`) to every match result, so each score can be explained from its stored signals (distance, matched EMR, overlap %, etc.) without re-running the scorers.
- [x] Replaced the older `missing_*` flags with finer-grained ones: `no_location_data`, `location_province_only`, `no_physician_emr`, `no_job_emr`, `emr_mismatch`, `no_duration_data`, `low_date_overlap`, `no_job_date_range`.
- [x] Tightened the `ScoreBreakdown` typedef so the detail shapes are first-class types, not loose `Object` blobs.
- [x] Added a unit test suite for `scoreMatch` covering identity, breakdown shape, and every flag scenario.
- [x] Added a round-trip test that detail blobs survive the combine-and-rank stage untouched.
- [x] Added `npm run requeue` to bulk-trigger matching for all physicians, all jobs, or both, against the orchestration service.
- [x] Added `npm run check-detail` to report detail-coverage %, flag distribution, and per-category method distribution, with `--sample-flag` / `--sample-method` to pull an example document.